### PR TITLE
Bump `subsquid/substrate-processor` version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.4.2
+
+- **FIX**: Bump Subsquid processor (`@subsquid/substrate-processor`) version to include fix for switching to RPC when processing unfinalized blocks.
+
 # 1.4.1
 
 - **FIX**: Install `bash` in Dockerfile, since it does not come pre-installed in `node:18-alpine` image.

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@subsquid/archive-registry": "^3.3.0",
         "@subsquid/graphql-server": "^4.3.1",
         "@subsquid/ss58": "^2.0.1",
-        "@subsquid/substrate-processor": "^7.2.1",
+        "@subsquid/substrate-processor": "^8.1.1",
         "@subsquid/typeorm-migration": "^1.2.2",
         "@subsquid/typeorm-store": "^1.2.4",
         "async-lock": "^1.3.1",
@@ -6450,19 +6450,19 @@
       }
     },
     "node_modules/@subsquid/http-client": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@subsquid/http-client/-/http-client-1.3.1.tgz",
-      "integrity": "sha512-ZBuYNW9IOvigvpntZvM0tzAY5Llr44NYswOzGwJpCjOnWF7EotzeJRMwDH0Zv5hXSMFvX3UBACP+PxmwDvma5A==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@subsquid/http-client/-/http-client-1.3.2.tgz",
+      "integrity": "sha512-N9fXB2TCYzzT4CNoTibpgk4lMFNU463/ZQcSstPPMIpZA9QdDjY+mNdjLTi8L+4DzimgjEbwYfLQX5aINYvkMA==",
       "dependencies": {
-        "@subsquid/logger": "^1.3.1",
-        "@subsquid/util-internal": "^2.5.2",
+        "@subsquid/logger": "^1.3.2",
+        "@subsquid/util-internal": "^3.0.0",
         "node-fetch": "^3.3.2"
       }
     },
     "node_modules/@subsquid/http-client/node_modules/@subsquid/util-internal": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-2.5.2.tgz",
-      "integrity": "sha512-N7lfZdWEkM35jG5wdGYx25TJKGGLMOx9VInSeRhW9T/3BEmHAuSWI2mIIYnZ8w5L041V8HGo61ijWF6qsXvZjg=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-3.0.0.tgz",
+      "integrity": "sha512-aGPTiLF21N9f67DgHS4PBR8d6mdvXHTOIhr2mFQPX7GQCgZhNlCZDM/1Sqn+teJawCy3w6Y9f6KOtVbN4T5SFQ=="
     },
     "node_modules/@subsquid/http-client/node_modules/node-fetch": {
       "version": "3.3.2",
@@ -6482,12 +6482,12 @@
       }
     },
     "node_modules/@subsquid/logger": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@subsquid/logger/-/logger-1.3.1.tgz",
-      "integrity": "sha512-OBhelb0HbhqSygq/IxEm9PPX8thQSDiCPV45UlCqWOoQ9UpiROiQLL+2nwt+HAHQq+LlHTzQmGXV43eabrTfwQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@subsquid/logger/-/logger-1.3.2.tgz",
+      "integrity": "sha512-5YPdeRu0WD9iBak+r3S8blBeg2uyliPUlmCjj/ZE6dpXmXsSN9T+ZYrNeDr9eAbRV7OXVI49lSfCuAGenFcYjQ==",
       "dependencies": {
-        "@subsquid/util-internal-hex": "^1.2.1",
-        "@subsquid/util-internal-json": "^1.2.1",
+        "@subsquid/util-internal-hex": "^1.2.2",
+        "@subsquid/util-internal-json": "^1.2.2",
         "supports-color": "^8.1.1"
       }
     },
@@ -6624,22 +6624,49 @@
       }
     },
     "node_modules/@subsquid/rpc-client": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@subsquid/rpc-client/-/rpc-client-4.4.2.tgz",
-      "integrity": "sha512-Zo/KuFNiwKblKCUDpXUNbeshxEpCX44CtBKbzr4f5zFNdwxuH7FjwFnZk4X5YZUVnbcTF6cmqhH5RwRkKBgPfQ==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/rpc-client/-/rpc-client-4.6.0.tgz",
+      "integrity": "sha512-fVTsVOag6Ge7hRqV+st9p+E+BgQa5PPu1uJns5IXSrRtIuAuy++w0OsB3WNA+EC8DZarpllxi7I3snzJpis/xQ==",
       "dependencies": {
-        "@subsquid/http-client": "^1.3.1",
-        "@subsquid/logger": "^1.3.1",
-        "@subsquid/util-internal": "^2.5.2",
+        "@subsquid/http-client": "^1.3.2",
+        "@subsquid/logger": "^1.3.2",
+        "@subsquid/util-internal": "^3.0.0",
         "@subsquid/util-internal-binary-heap": "^1.0.0",
-        "@subsquid/util-internal-counters": "^1.3.1",
+        "@subsquid/util-internal-counters": "^1.3.2",
         "websocket": "^1.0.34"
       }
     },
     "node_modules/@subsquid/rpc-client/node_modules/@subsquid/util-internal": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-2.5.2.tgz",
-      "integrity": "sha512-N7lfZdWEkM35jG5wdGYx25TJKGGLMOx9VInSeRhW9T/3BEmHAuSWI2mIIYnZ8w5L041V8HGo61ijWF6qsXvZjg=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-3.0.0.tgz",
+      "integrity": "sha512-aGPTiLF21N9f67DgHS4PBR8d6mdvXHTOIhr2mFQPX7GQCgZhNlCZDM/1Sqn+teJawCy3w6Y9f6KOtVbN4T5SFQ=="
+    },
+    "node_modules/@subsquid/scale-codec": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@subsquid/scale-codec/-/scale-codec-4.0.1.tgz",
+      "integrity": "sha512-H3mi5GIvlrvOSJVSYQRNnaiulSDktPF4TwUvquAgN86tN4kokyX8XcEM2Htrm1sVWRtMi7SgYpyVR5Yg5iPKUQ==",
+      "dependencies": {
+        "@subsquid/util-internal-hex": "^1.2.2",
+        "@subsquid/util-internal-json": "^1.2.2"
+      }
+    },
+    "node_modules/@subsquid/scale-type-system": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@subsquid/scale-type-system/-/scale-type-system-1.0.2.tgz",
+      "integrity": "sha512-bZSUGO/Hfnf/+luZ8lWEsGqr9iIiQeaifmXEiOGBpr5Ace6H+pPY3lFmDTPWigoqt7VxrhRO0jvk5RLAyeBJvg==",
+      "peer": true,
+      "dependencies": {
+        "@subsquid/util-internal": "^3.0.0"
+      },
+      "peerDependencies": {
+        "@subsquid/scale-codec": "^4.0.1"
+      }
+    },
+    "node_modules/@subsquid/scale-type-system/node_modules/@subsquid/util-internal": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-3.0.0.tgz",
+      "integrity": "sha512-aGPTiLF21N9f67DgHS4PBR8d6mdvXHTOIhr2mFQPX7GQCgZhNlCZDM/1Sqn+teJawCy3w6Y9f6KOtVbN4T5SFQ==",
+      "peer": true
     },
     "node_modules/@subsquid/ss58": {
       "version": "2.0.1",
@@ -6663,6 +6690,51 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
       "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
+    },
+    "node_modules/@subsquid/substrate-data": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@subsquid/substrate-data/-/substrate-data-4.0.1.tgz",
+      "integrity": "sha512-1eluGvrSiXuQZJdg9Ihtbem0Kl72Ahz54Nexi+UM2WviPmSn7XYA2k/OUBK9dD6KBIAFayN7r99S6YtDgJhrqA==",
+      "dependencies": {
+        "@subsquid/scale-codec": "^4.0.1",
+        "@subsquid/substrate-data-raw": "^1.1.0",
+        "@subsquid/util-internal": "^3.0.0",
+        "@subsquid/util-internal-hex": "^1.2.2",
+        "@subsquid/util-internal-ingest-tools": "^1.1.0",
+        "@subsquid/util-internal-range": "^0.1.0",
+        "@subsquid/util-xxhash": "^1.2.2",
+        "@substrate/calc": "^0.2.8",
+        "blake2b": "^2.1.4"
+      },
+      "peerDependencies": {
+        "@subsquid/rpc-client": "^4.6.0",
+        "@subsquid/substrate-runtime": "^1.0.2"
+      }
+    },
+    "node_modules/@subsquid/substrate-data-raw": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/substrate-data-raw/-/substrate-data-raw-1.1.0.tgz",
+      "integrity": "sha512-wiFF2sE7enBSfr84voGdQ4o26nxB1lLF2PcuU7QJawebPWNtQCCcBfRCWZekaqhkF+Y/4uFpOI3krTFvqlo5rw==",
+      "dependencies": {
+        "@subsquid/util-internal": "^3.0.0",
+        "@subsquid/util-internal-ingest-tools": "^1.1.0",
+        "@subsquid/util-internal-range": "^0.1.0",
+        "@subsquid/util-timeout": "^2.3.2"
+      },
+      "peerDependencies": {
+        "@subsquid/logger": "^1.3.2",
+        "@subsquid/rpc-client": "^4.6.0"
+      }
+    },
+    "node_modules/@subsquid/substrate-data-raw/node_modules/@subsquid/util-internal": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-3.0.0.tgz",
+      "integrity": "sha512-aGPTiLF21N9f67DgHS4PBR8d6mdvXHTOIhr2mFQPX7GQCgZhNlCZDM/1Sqn+teJawCy3w6Y9f6KOtVbN4T5SFQ=="
+    },
+    "node_modules/@subsquid/substrate-data/node_modules/@subsquid/util-internal": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-3.0.0.tgz",
+      "integrity": "sha512-aGPTiLF21N9f67DgHS4PBR8d6mdvXHTOIhr2mFQPX7GQCgZhNlCZDM/1Sqn+teJawCy3w6Y9f6KOtVbN4T5SFQ=="
     },
     "node_modules/@subsquid/substrate-metadata-explorer": {
       "version": "3.1.1",
@@ -6690,131 +6762,51 @@
       "dev": true
     },
     "node_modules/@subsquid/substrate-processor": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/@subsquid/substrate-processor/-/substrate-processor-7.2.1.tgz",
-      "integrity": "sha512-9T/wQIaDt4HfkioFQ8nGMc+/N/mEskiYFhQdvT0FYwdKxr3qbyvsbT2qoZfDS/i9J/d2y/39YKrtCMBKOwf65w==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@subsquid/substrate-processor/-/substrate-processor-8.1.1.tgz",
+      "integrity": "sha512-SB4rsNZDihzSy9PuVKi/KuoYhl/apnQaJAIAb7nBOYlk1kOzG3+jEEk3SxR53JYFuTelrwK/AY9lS4e+LwiDCg==",
       "dependencies": {
-        "@subsquid/http-client": "^1.3.1",
-        "@subsquid/logger": "^1.3.1",
-        "@subsquid/rpc-client": "^4.4.2",
-        "@subsquid/substrate-data": "^3.0.1",
-        "@subsquid/substrate-data-raw": "^0.1.0",
-        "@subsquid/util-internal": "^2.5.2",
-        "@subsquid/util-internal-archive-client": "^0.0.1",
-        "@subsquid/util-internal-hex": "^1.2.1",
-        "@subsquid/util-internal-json": "^1.2.1",
-        "@subsquid/util-internal-processor-tools": "^3.1.0"
+        "@subsquid/http-client": "^1.3.2",
+        "@subsquid/logger": "^1.3.2",
+        "@subsquid/rpc-client": "^4.6.0",
+        "@subsquid/substrate-data": "^4.0.0",
+        "@subsquid/substrate-data-raw": "^1.0.1",
+        "@subsquid/util-internal": "^3.0.0",
+        "@subsquid/util-internal-archive-client": "^0.1.0",
+        "@subsquid/util-internal-hex": "^1.2.2",
+        "@subsquid/util-internal-ingest-tools": "^1.1.0",
+        "@subsquid/util-internal-json": "^1.2.2",
+        "@subsquid/util-internal-processor-tools": "^4.0.0",
+        "@subsquid/util-internal-range": "^0.1.0"
       },
       "peerDependencies": {
-        "@subsquid/substrate-runtime": "^1.0.1"
-      }
-    },
-    "node_modules/@subsquid/substrate-processor/node_modules/@subsquid/scale-codec": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@subsquid/scale-codec/-/scale-codec-4.0.0.tgz",
-      "integrity": "sha512-aVqcy1KeQiYhL3lRLZJcRVuBOmh88zQKqEdxU/7gJCj/gvBF9+Isd16oE0xuA5xwlGcFHbRfUFSON5EP2Lv8Eg==",
-      "dependencies": {
-        "@subsquid/util-internal-hex": "^1.2.1",
-        "@subsquid/util-internal-json": "^1.2.1"
-      }
-    },
-    "node_modules/@subsquid/substrate-processor/node_modules/@subsquid/substrate-data": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@subsquid/substrate-data/-/substrate-data-3.0.1.tgz",
-      "integrity": "sha512-zmZGtwYwNi50siU5k0r8YRXlJPNsls1E6y1N+Yv7driNdsolKhXdcHKLoRIaiXRlV/QGkuSh/vNaLxebxiL1TQ==",
-      "dependencies": {
-        "@subsquid/scale-codec": "^4.0.0",
-        "@subsquid/substrate-data-raw": "^0.1.0",
-        "@subsquid/util-internal": "^2.5.2",
-        "@subsquid/util-internal-hex": "^1.2.1",
-        "@subsquid/util-internal-ingest-tools": "^0.0.2",
-        "@subsquid/util-internal-range": "^0.0.1",
-        "@subsquid/util-xxhash": "^1.2.1",
-        "@substrate/calc": "^0.2.8",
-        "blake2b": "^2.1.4"
-      },
-      "peerDependencies": {
-        "@subsquid/rpc-client": "^4.4.2",
-        "@subsquid/substrate-runtime": "^1.0.1"
-      }
-    },
-    "node_modules/@subsquid/substrate-processor/node_modules/@subsquid/substrate-data-raw": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@subsquid/substrate-data-raw/-/substrate-data-raw-0.1.0.tgz",
-      "integrity": "sha512-0540hjZzUgeVjqy7UqKcTPKBsun2eisv9JR0ks3WDHPLabyWy4TolbE1WWqCo4B8wBmLEm5+vTL/BtM/AkHrYg==",
-      "dependencies": {
-        "@subsquid/util-internal": "^2.5.2",
-        "@subsquid/util-internal-ingest-tools": "^0.0.2",
-        "@subsquid/util-internal-range": "^0.0.1"
-      },
-      "peerDependencies": {
-        "@subsquid/rpc-client": "^4.4.2"
+        "@subsquid/substrate-runtime": "^1.0.2"
       }
     },
     "node_modules/@subsquid/substrate-processor/node_modules/@subsquid/util-internal": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-2.5.2.tgz",
-      "integrity": "sha512-N7lfZdWEkM35jG5wdGYx25TJKGGLMOx9VInSeRhW9T/3BEmHAuSWI2mIIYnZ8w5L041V8HGo61ijWF6qsXvZjg=="
-    },
-    "node_modules/@subsquid/substrate-processor/node_modules/@subsquid/util-internal-archive-client": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-archive-client/-/util-internal-archive-client-0.0.1.tgz",
-      "integrity": "sha512-Sr+m1vxAArPIdsjyKVOpjU57JlVujBpI8NEeHqeA6twSb40wasOLAeq775WyYFynucltNRSgIiwXBIo0t02D6g==",
-      "dependencies": {
-        "@subsquid/http-client": "^1.3.1",
-        "@subsquid/util-internal": "^2.5.2",
-        "@subsquid/util-internal-range": "^0.0.1"
-      },
-      "peerDependencies": {
-        "@subsquid/logger": "^1.3.1"
-      },
-      "peerDependenciesMeta": {
-        "@subsquid/logger": {
-          "optional": true
-        }
-      }
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-3.0.0.tgz",
+      "integrity": "sha512-aGPTiLF21N9f67DgHS4PBR8d6mdvXHTOIhr2mFQPX7GQCgZhNlCZDM/1Sqn+teJawCy3w6Y9f6KOtVbN4T5SFQ=="
     },
     "node_modules/@subsquid/substrate-runtime": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@subsquid/substrate-runtime/-/substrate-runtime-1.0.1.tgz",
-      "integrity": "sha512-L7ln2EaIfl99uAbkz3Nw6oIXdpj2yfBk5qUyOJ/nOm5WHGBE3NKw0nIfgnC6EbbsNJKZZfJT0Tm+eRZZlUakug==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@subsquid/substrate-runtime/-/substrate-runtime-1.0.3.tgz",
+      "integrity": "sha512-3uNZqyHKzoMkSHQTZIJl1G7NiKyFl4cmDzVY3dU0o4VZhGNUAmR+HecT3WBkMMYye6uhDAeXsbVECa3ZnMM3gQ==",
       "peer": true,
       "dependencies": {
-        "@subsquid/scale-codec": "^4.0.0",
-        "@subsquid/scale-type-system": "^1.0.0",
-        "@subsquid/util-internal": "^2.5.2",
-        "@subsquid/util-internal-hex": "^1.2.1",
-        "@subsquid/util-naming": "^1.2.1",
-        "@subsquid/util-xxhash": "^1.2.1",
+        "@subsquid/scale-codec": "^4.0.1",
+        "@subsquid/scale-type-system": "^1.0.2",
+        "@subsquid/util-internal": "^3.0.0",
+        "@subsquid/util-internal-hex": "^1.2.2",
+        "@subsquid/util-naming": "^1.2.2",
+        "@subsquid/util-xxhash": "^1.2.2",
         "blake2b": "^2.1.4"
       }
     },
-    "node_modules/@subsquid/substrate-runtime/node_modules/@subsquid/scale-codec": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@subsquid/scale-codec/-/scale-codec-4.0.0.tgz",
-      "integrity": "sha512-aVqcy1KeQiYhL3lRLZJcRVuBOmh88zQKqEdxU/7gJCj/gvBF9+Isd16oE0xuA5xwlGcFHbRfUFSON5EP2Lv8Eg==",
-      "peer": true,
-      "dependencies": {
-        "@subsquid/util-internal-hex": "^1.2.1",
-        "@subsquid/util-internal-json": "^1.2.1"
-      }
-    },
-    "node_modules/@subsquid/substrate-runtime/node_modules/@subsquid/scale-type-system": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@subsquid/scale-type-system/-/scale-type-system-1.0.1.tgz",
-      "integrity": "sha512-CjY5nBzGrbRcOH//lOwNHbBjHtHD0t27SirdIAFre/Mp4fLIiv6gEkIgNYu+lwAjMvuFkLkcw7JGmwXvLNepNw==",
-      "peer": true,
-      "dependencies": {
-        "@subsquid/util-internal": "^2.5.2"
-      },
-      "peerDependencies": {
-        "@subsquid/scale-codec": "^4.0.0"
-      }
-    },
     "node_modules/@subsquid/substrate-runtime/node_modules/@subsquid/util-internal": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-2.5.2.tgz",
-      "integrity": "sha512-N7lfZdWEkM35jG5wdGYx25TJKGGLMOx9VInSeRhW9T/3BEmHAuSWI2mIIYnZ8w5L041V8HGo61ijWF6qsXvZjg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-3.0.0.tgz",
+      "integrity": "sha512-aGPTiLF21N9f67DgHS4PBR8d6mdvXHTOIhr2mFQPX7GQCgZhNlCZDM/1Sqn+teJawCy3w6Y9f6KOtVbN4T5SFQ==",
       "peer": true
     },
     "node_modules/@subsquid/substrate-typegen": {
@@ -6933,6 +6925,29 @@
       "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-1.1.0.tgz",
       "integrity": "sha512-O6m666RDcWEw4vb3bmeNZKlAa1rGOHQvS0nhZFTBXnxZpqK/pU5N0jrQ7X/3is0pY2RKxFoxTurZjhv4QdxtqA=="
     },
+    "node_modules/@subsquid/util-internal-archive-client": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-archive-client/-/util-internal-archive-client-0.1.0.tgz",
+      "integrity": "sha512-bXFNZvXduKzG3NjPLmFPU5B+r+UHXT45Yr5YOpgD9sZvrHbNc/n877jSEt1qnzUJKnTl1hxtXlXvpwIBEjKT3Q==",
+      "dependencies": {
+        "@subsquid/util-internal": "^3.0.0",
+        "@subsquid/util-internal-range": "^0.1.0"
+      },
+      "peerDependencies": {
+        "@subsquid/http-client": "^1.3.2",
+        "@subsquid/logger": "^1.3.2"
+      },
+      "peerDependenciesMeta": {
+        "@subsquid/logger": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@subsquid/util-internal-archive-client/node_modules/@subsquid/util-internal": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-3.0.0.tgz",
+      "integrity": "sha512-aGPTiLF21N9f67DgHS4PBR8d6mdvXHTOIhr2mFQPX7GQCgZhNlCZDM/1Sqn+teJawCy3w6Y9f6KOtVbN4T5SFQ=="
+    },
     "node_modules/@subsquid/util-internal-binary-heap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@subsquid/util-internal-binary-heap/-/util-internal-binary-heap-1.0.0.tgz",
@@ -6962,88 +6977,96 @@
       }
     },
     "node_modules/@subsquid/util-internal-counters": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-counters/-/util-internal-counters-1.3.1.tgz",
-      "integrity": "sha512-bc22t8lEvoCBn31F+B763E81+ZDaL7ufpwr0VLXZzcA5wZ6NEqqRfs4bJtPeBNGEjyeLLrItXWxfjSkR7sGKAg=="
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-counters/-/util-internal-counters-1.3.2.tgz",
+      "integrity": "sha512-GxpOIL36JXSo0KdOT7k6CsI4DY804rn/X7pTdfKhych0ReHaDghnwNyvgb7Njv9euEHWUt4MxXbfQ9YrbpPDng=="
     },
     "node_modules/@subsquid/util-internal-hex": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-hex/-/util-internal-hex-1.2.1.tgz",
-      "integrity": "sha512-R7TYDsftjguapzWia97WGvcF4s65VKArzSga5i1i4aZSq9Z330kPYpgAUkqDGsJqD/Ki3PTE4cXhuKLRyMHPvg=="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-hex/-/util-internal-hex-1.2.2.tgz",
+      "integrity": "sha512-E43HVqf23jP5hvtWF9GsiN8luANjnJ1daR2SVTwaIUAYU/uNjv1Bi6tHz2uexlflBhyxAgBDmHgunXZ45wQTIw=="
     },
     "node_modules/@subsquid/util-internal-http-server": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-http-server/-/util-internal-http-server-1.2.1.tgz",
-      "integrity": "sha512-aQIodM3xWDu8wxllOONU5Fy6hmYYAZzS2PglC2FfdUi6HUxaZ8aCUkjFisG56tglhsoAh/TQSQX1YhCX00MCcg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-http-server/-/util-internal-http-server-1.2.2.tgz",
+      "integrity": "sha512-B2SOSz8frUkXarbsELljew25iXFFyATEtS8NV31xKUXmhYfPklqrcF4YNJ/aLlfCtVOiR042YKVZDx2T8RbN6w==",
       "dependencies": {
         "stoppable": "^1.1.0"
       }
     },
     "node_modules/@subsquid/util-internal-ingest-tools": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-ingest-tools/-/util-internal-ingest-tools-0.0.2.tgz",
-      "integrity": "sha512-Nx5LDWq9B1sVAXg6qDI0zVmzfwP1Mk5Rrn79OJc4eKLvZTrTIk2vyM5SB4n1kwQk6KRuQYI9dfiNWdcm+9rGfA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-ingest-tools/-/util-internal-ingest-tools-1.1.0.tgz",
+      "integrity": "sha512-Zk5IPrclv+OrAV6EFQWGQS86YfN51/tLKKW137VzFPCWNEBSPCXu5lYe/hCwwW34k+gtf5TYLb3s69d2P1e/lg==",
       "dependencies": {
-        "@subsquid/logger": "^1.3.1",
-        "@subsquid/util-internal": "^2.5.2",
-        "@subsquid/util-internal-range": "^0.0.1"
+        "@subsquid/logger": "^1.3.2",
+        "@subsquid/util-internal": "^3.0.0",
+        "@subsquid/util-internal-range": "^0.1.0"
+      },
+      "peerDependencies": {
+        "@subsquid/util-internal-archive-client": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@subsquid/util-internal-archive-client": {
+          "optional": true
+        }
       }
     },
     "node_modules/@subsquid/util-internal-ingest-tools/node_modules/@subsquid/util-internal": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-2.5.2.tgz",
-      "integrity": "sha512-N7lfZdWEkM35jG5wdGYx25TJKGGLMOx9VInSeRhW9T/3BEmHAuSWI2mIIYnZ8w5L041V8HGo61ijWF6qsXvZjg=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-3.0.0.tgz",
+      "integrity": "sha512-aGPTiLF21N9f67DgHS4PBR8d6mdvXHTOIhr2mFQPX7GQCgZhNlCZDM/1Sqn+teJawCy3w6Y9f6KOtVbN4T5SFQ=="
     },
     "node_modules/@subsquid/util-internal-json": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-json/-/util-internal-json-1.2.1.tgz",
-      "integrity": "sha512-Jtbhur/QaRk727fiZ/w8so0M0o4BIkfvnT6zBnC3s1mQ9fKve0Q6aj22gbimpX7Whj6tAGF0Bz8LFhbAethbkA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-json/-/util-internal-json-1.2.2.tgz",
+      "integrity": "sha512-+axQnlkIzscdy0T/vR1Dez/2NVCryWgB3OocMGJcx2GjhHVkmuJSLFqOdk9o90OocfQFC57NTZx22oa2yd+4Yw==",
       "dependencies": {
-        "@subsquid/util-internal-hex": "^1.2.1"
+        "@subsquid/util-internal-hex": "^1.2.2"
       }
     },
     "node_modules/@subsquid/util-internal-processor-tools": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-processor-tools/-/util-internal-processor-tools-3.1.0.tgz",
-      "integrity": "sha512-uEa8Bw/xvSfiagbK8IFt1OEgR7hacfblPZXH5EV4cAIKoIVOonhnkJEPRWqI3ZaDHl+8Z9p909tlsEd46sXenw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-processor-tools/-/util-internal-processor-tools-4.0.1.tgz",
+      "integrity": "sha512-2+IOze7VkgUuJqRThzq6QDO+xNd6CAbPUgtjgOi6EB3/ImrJXEjENBOFzTVSTP0Ri+kT/CyoyBPniyGBGzogiA==",
       "dependencies": {
-        "@subsquid/logger": "^1.3.1",
-        "@subsquid/util-internal": "^2.5.2",
-        "@subsquid/util-internal-counters": "^1.3.1",
-        "@subsquid/util-internal-prometheus-server": "^1.2.1",
-        "@subsquid/util-internal-range": "^0.0.1",
+        "@subsquid/logger": "^1.3.2",
+        "@subsquid/util-internal": "^3.0.0",
+        "@subsquid/util-internal-counters": "^1.3.2",
+        "@subsquid/util-internal-prometheus-server": "^1.2.2",
+        "@subsquid/util-internal-range": "^0.1.0",
         "prom-client": "^14.2.0"
       }
     },
     "node_modules/@subsquid/util-internal-processor-tools/node_modules/@subsquid/util-internal": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-2.5.2.tgz",
-      "integrity": "sha512-N7lfZdWEkM35jG5wdGYx25TJKGGLMOx9VInSeRhW9T/3BEmHAuSWI2mIIYnZ8w5L041V8HGo61ijWF6qsXvZjg=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-3.0.0.tgz",
+      "integrity": "sha512-aGPTiLF21N9f67DgHS4PBR8d6mdvXHTOIhr2mFQPX7GQCgZhNlCZDM/1Sqn+teJawCy3w6Y9f6KOtVbN4T5SFQ=="
     },
     "node_modules/@subsquid/util-internal-prometheus-server": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-prometheus-server/-/util-internal-prometheus-server-1.2.1.tgz",
-      "integrity": "sha512-GhbsEmv0xAkaBaxwZGRavMIO0h68V6LctZIvxsrrPr695bI1mrXKSYDvVvUwLXQ3aDPy9PIQiKdbSjNa60JW6Q==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-prometheus-server/-/util-internal-prometheus-server-1.2.2.tgz",
+      "integrity": "sha512-KOjokVhs+qJOZSkM+NPZ/XE5bGvEGGJkVbMaJJfaZ+UfZQPQDfVJrI2rPV5D9FwzctxKG9b7lPArryBIUsgrZw==",
       "dependencies": {
-        "@subsquid/util-internal-http-server": "^1.2.1"
+        "@subsquid/util-internal-http-server": "^1.2.2"
       },
       "peerDependencies": {
         "prom-client": "^14.2.0"
       }
     },
     "node_modules/@subsquid/util-internal-range": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-range/-/util-internal-range-0.0.1.tgz",
-      "integrity": "sha512-9hqlPdTJeR9j9+1L3ymOPC0/qJ2IemGkrHmkTq+gwkjtGKmiXuXw4WLgt0Ps5aeupWKfP7UFy1hDE9DZQFseog==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-range/-/util-internal-range-0.1.0.tgz",
+      "integrity": "sha512-+pJeJyH0oetqu2eRwOkP7NCSaCGzLpCCNpS9Fwi968RL+LfWSKn+wGUX6Ulf0afSslvrQ/34ZtyWdjyya1AGxA==",
       "dependencies": {
-        "@subsquid/util-internal": "^2.5.2",
+        "@subsquid/util-internal": "^3.0.0",
         "@subsquid/util-internal-binary-heap": "^1.0.0"
       }
     },
     "node_modules/@subsquid/util-internal-range/node_modules/@subsquid/util-internal": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-2.5.2.tgz",
-      "integrity": "sha512-N7lfZdWEkM35jG5wdGYx25TJKGGLMOx9VInSeRhW9T/3BEmHAuSWI2mIIYnZ8w5L041V8HGo61ijWF6qsXvZjg=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-3.0.0.tgz",
+      "integrity": "sha512-aGPTiLF21N9f67DgHS4PBR8d6mdvXHTOIhr2mFQPX7GQCgZhNlCZDM/1Sqn+teJawCy3w6Y9f6KOtVbN4T5SFQ=="
     },
     "node_modules/@subsquid/util-internal-read-lines": {
       "version": "1.2.1",
@@ -7052,18 +7075,23 @@
       "dev": true
     },
     "node_modules/@subsquid/util-naming": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-naming/-/util-naming-1.2.1.tgz",
-      "integrity": "sha512-l5rvAXG7TxMPeB5kFTTZWisgN0DNe1mVBHT2V2/nxUx4sOfYfneWIN/+02YqJI/GHX9FoOTB6ru7WLfQEMhvhg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-naming/-/util-naming-1.2.2.tgz",
+      "integrity": "sha512-NveXOiAbWiWkWd3Iv2jEwSAKvQHOG/HfIsPmmNab8TPX/XgJ6J5Ngx6lHEiqs746m4sOhZ2yipxKAEDgrERaxA==",
       "dependencies": {
         "camelcase": "^6.3.0",
         "inflected": "^2.1.0"
       }
     },
+    "node_modules/@subsquid/util-timeout": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-timeout/-/util-timeout-2.3.2.tgz",
+      "integrity": "sha512-DVUnuiWAX7/4ZvbzuHENUShEEV4G0M38mQ/+R8DpHxwpCSrtEaSRaUMwdyUSn/WVqR7wo9+jkLCxFjE5feCURQ=="
+    },
     "node_modules/@subsquid/util-xxhash": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-xxhash/-/util-xxhash-1.2.1.tgz",
-      "integrity": "sha512-wobgbKK0fd+3ufUVjxcx4zaYII9JY7hbIStyO9M9Q5xrdihiWM5APX27sRuoO8X8oSj34v44JpIMxC8Rbpy3xQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-xxhash/-/util-xxhash-1.2.2.tgz",
+      "integrity": "sha512-S49O4bxs80y3/oBl1xKBE/zzvDPLr88yE+03zfOXaNj/wesTGzicqBxhzDULmyo6kpdRmc0ZPOZCQ3U6gNQpxQ==",
       "dependencies": {
         "xxhash-wasm": "^1.0.2",
         "xxhashjs": "^0.2.2"
@@ -21434,19 +21462,19 @@
       }
     },
     "@subsquid/http-client": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@subsquid/http-client/-/http-client-1.3.1.tgz",
-      "integrity": "sha512-ZBuYNW9IOvigvpntZvM0tzAY5Llr44NYswOzGwJpCjOnWF7EotzeJRMwDH0Zv5hXSMFvX3UBACP+PxmwDvma5A==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@subsquid/http-client/-/http-client-1.3.2.tgz",
+      "integrity": "sha512-N9fXB2TCYzzT4CNoTibpgk4lMFNU463/ZQcSstPPMIpZA9QdDjY+mNdjLTi8L+4DzimgjEbwYfLQX5aINYvkMA==",
       "requires": {
-        "@subsquid/logger": "^1.3.1",
-        "@subsquid/util-internal": "^2.5.2",
+        "@subsquid/logger": "^1.3.2",
+        "@subsquid/util-internal": "^3.0.0",
         "node-fetch": "^3.3.2"
       },
       "dependencies": {
         "@subsquid/util-internal": {
-          "version": "2.5.2",
-          "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-2.5.2.tgz",
-          "integrity": "sha512-N7lfZdWEkM35jG5wdGYx25TJKGGLMOx9VInSeRhW9T/3BEmHAuSWI2mIIYnZ8w5L041V8HGo61ijWF6qsXvZjg=="
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-3.0.0.tgz",
+          "integrity": "sha512-aGPTiLF21N9f67DgHS4PBR8d6mdvXHTOIhr2mFQPX7GQCgZhNlCZDM/1Sqn+teJawCy3w6Y9f6KOtVbN4T5SFQ=="
         },
         "node-fetch": {
           "version": "3.3.2",
@@ -21461,12 +21489,12 @@
       }
     },
     "@subsquid/logger": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@subsquid/logger/-/logger-1.3.1.tgz",
-      "integrity": "sha512-OBhelb0HbhqSygq/IxEm9PPX8thQSDiCPV45UlCqWOoQ9UpiROiQLL+2nwt+HAHQq+LlHTzQmGXV43eabrTfwQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@subsquid/logger/-/logger-1.3.2.tgz",
+      "integrity": "sha512-5YPdeRu0WD9iBak+r3S8blBeg2uyliPUlmCjj/ZE6dpXmXsSN9T+ZYrNeDr9eAbRV7OXVI49lSfCuAGenFcYjQ==",
       "requires": {
-        "@subsquid/util-internal-hex": "^1.2.1",
-        "@subsquid/util-internal-json": "^1.2.1",
+        "@subsquid/util-internal-hex": "^1.2.2",
+        "@subsquid/util-internal-json": "^1.2.2",
         "supports-color": "^8.1.1"
       }
     },
@@ -21552,22 +21580,48 @@
       }
     },
     "@subsquid/rpc-client": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@subsquid/rpc-client/-/rpc-client-4.4.2.tgz",
-      "integrity": "sha512-Zo/KuFNiwKblKCUDpXUNbeshxEpCX44CtBKbzr4f5zFNdwxuH7FjwFnZk4X5YZUVnbcTF6cmqhH5RwRkKBgPfQ==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/rpc-client/-/rpc-client-4.6.0.tgz",
+      "integrity": "sha512-fVTsVOag6Ge7hRqV+st9p+E+BgQa5PPu1uJns5IXSrRtIuAuy++w0OsB3WNA+EC8DZarpllxi7I3snzJpis/xQ==",
       "requires": {
-        "@subsquid/http-client": "^1.3.1",
-        "@subsquid/logger": "^1.3.1",
-        "@subsquid/util-internal": "^2.5.2",
+        "@subsquid/http-client": "^1.3.2",
+        "@subsquid/logger": "^1.3.2",
+        "@subsquid/util-internal": "^3.0.0",
         "@subsquid/util-internal-binary-heap": "^1.0.0",
-        "@subsquid/util-internal-counters": "^1.3.1",
+        "@subsquid/util-internal-counters": "^1.3.2",
         "websocket": "^1.0.34"
       },
       "dependencies": {
         "@subsquid/util-internal": {
-          "version": "2.5.2",
-          "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-2.5.2.tgz",
-          "integrity": "sha512-N7lfZdWEkM35jG5wdGYx25TJKGGLMOx9VInSeRhW9T/3BEmHAuSWI2mIIYnZ8w5L041V8HGo61ijWF6qsXvZjg=="
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-3.0.0.tgz",
+          "integrity": "sha512-aGPTiLF21N9f67DgHS4PBR8d6mdvXHTOIhr2mFQPX7GQCgZhNlCZDM/1Sqn+teJawCy3w6Y9f6KOtVbN4T5SFQ=="
+        }
+      }
+    },
+    "@subsquid/scale-codec": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@subsquid/scale-codec/-/scale-codec-4.0.1.tgz",
+      "integrity": "sha512-H3mi5GIvlrvOSJVSYQRNnaiulSDktPF4TwUvquAgN86tN4kokyX8XcEM2Htrm1sVWRtMi7SgYpyVR5Yg5iPKUQ==",
+      "requires": {
+        "@subsquid/util-internal-hex": "^1.2.2",
+        "@subsquid/util-internal-json": "^1.2.2"
+      }
+    },
+    "@subsquid/scale-type-system": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@subsquid/scale-type-system/-/scale-type-system-1.0.2.tgz",
+      "integrity": "sha512-bZSUGO/Hfnf/+luZ8lWEsGqr9iIiQeaifmXEiOGBpr5Ace6H+pPY3lFmDTPWigoqt7VxrhRO0jvk5RLAyeBJvg==",
+      "peer": true,
+      "requires": {
+        "@subsquid/util-internal": "^3.0.0"
+      },
+      "dependencies": {
+        "@subsquid/util-internal": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-3.0.0.tgz",
+          "integrity": "sha512-aGPTiLF21N9f67DgHS4PBR8d6mdvXHTOIhr2mFQPX7GQCgZhNlCZDM/1Sqn+teJawCy3w6Y9f6KOtVbN4T5SFQ==",
+          "peer": true
         }
       }
     },
@@ -21596,6 +21650,47 @@
         }
       }
     },
+    "@subsquid/substrate-data": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@subsquid/substrate-data/-/substrate-data-4.0.1.tgz",
+      "integrity": "sha512-1eluGvrSiXuQZJdg9Ihtbem0Kl72Ahz54Nexi+UM2WviPmSn7XYA2k/OUBK9dD6KBIAFayN7r99S6YtDgJhrqA==",
+      "requires": {
+        "@subsquid/scale-codec": "^4.0.1",
+        "@subsquid/substrate-data-raw": "^1.1.0",
+        "@subsquid/util-internal": "^3.0.0",
+        "@subsquid/util-internal-hex": "^1.2.2",
+        "@subsquid/util-internal-ingest-tools": "^1.1.0",
+        "@subsquid/util-internal-range": "^0.1.0",
+        "@subsquid/util-xxhash": "^1.2.2",
+        "@substrate/calc": "^0.2.8",
+        "blake2b": "^2.1.4"
+      },
+      "dependencies": {
+        "@subsquid/util-internal": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-3.0.0.tgz",
+          "integrity": "sha512-aGPTiLF21N9f67DgHS4PBR8d6mdvXHTOIhr2mFQPX7GQCgZhNlCZDM/1Sqn+teJawCy3w6Y9f6KOtVbN4T5SFQ=="
+        }
+      }
+    },
+    "@subsquid/substrate-data-raw": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/substrate-data-raw/-/substrate-data-raw-1.1.0.tgz",
+      "integrity": "sha512-wiFF2sE7enBSfr84voGdQ4o26nxB1lLF2PcuU7QJawebPWNtQCCcBfRCWZekaqhkF+Y/4uFpOI3krTFvqlo5rw==",
+      "requires": {
+        "@subsquid/util-internal": "^3.0.0",
+        "@subsquid/util-internal-ingest-tools": "^1.1.0",
+        "@subsquid/util-internal-range": "^0.1.0",
+        "@subsquid/util-timeout": "^2.3.2"
+      },
+      "dependencies": {
+        "@subsquid/util-internal": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-3.0.0.tgz",
+          "integrity": "sha512-aGPTiLF21N9f67DgHS4PBR8d6mdvXHTOIhr2mFQPX7GQCgZhNlCZDM/1Sqn+teJawCy3w6Y9f6KOtVbN4T5SFQ=="
+        }
+      }
+    },
     "@subsquid/substrate-metadata-explorer": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@subsquid/substrate-metadata-explorer/-/substrate-metadata-explorer-3.1.1.tgz",
@@ -21620,112 +21715,50 @@
       }
     },
     "@subsquid/substrate-processor": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/@subsquid/substrate-processor/-/substrate-processor-7.2.1.tgz",
-      "integrity": "sha512-9T/wQIaDt4HfkioFQ8nGMc+/N/mEskiYFhQdvT0FYwdKxr3qbyvsbT2qoZfDS/i9J/d2y/39YKrtCMBKOwf65w==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@subsquid/substrate-processor/-/substrate-processor-8.1.1.tgz",
+      "integrity": "sha512-SB4rsNZDihzSy9PuVKi/KuoYhl/apnQaJAIAb7nBOYlk1kOzG3+jEEk3SxR53JYFuTelrwK/AY9lS4e+LwiDCg==",
       "requires": {
-        "@subsquid/http-client": "^1.3.1",
-        "@subsquid/logger": "^1.3.1",
-        "@subsquid/rpc-client": "^4.4.2",
-        "@subsquid/substrate-data": "^3.0.1",
-        "@subsquid/substrate-data-raw": "^0.1.0",
-        "@subsquid/util-internal": "^2.5.2",
-        "@subsquid/util-internal-archive-client": "^0.0.1",
-        "@subsquid/util-internal-hex": "^1.2.1",
-        "@subsquid/util-internal-json": "^1.2.1",
-        "@subsquid/util-internal-processor-tools": "^3.1.0"
+        "@subsquid/http-client": "^1.3.2",
+        "@subsquid/logger": "^1.3.2",
+        "@subsquid/rpc-client": "^4.6.0",
+        "@subsquid/substrate-data": "^4.0.0",
+        "@subsquid/substrate-data-raw": "^1.0.1",
+        "@subsquid/util-internal": "^3.0.0",
+        "@subsquid/util-internal-archive-client": "^0.1.0",
+        "@subsquid/util-internal-hex": "^1.2.2",
+        "@subsquid/util-internal-ingest-tools": "^1.1.0",
+        "@subsquid/util-internal-json": "^1.2.2",
+        "@subsquid/util-internal-processor-tools": "^4.0.0",
+        "@subsquid/util-internal-range": "^0.1.0"
       },
       "dependencies": {
-        "@subsquid/scale-codec": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/@subsquid/scale-codec/-/scale-codec-4.0.0.tgz",
-          "integrity": "sha512-aVqcy1KeQiYhL3lRLZJcRVuBOmh88zQKqEdxU/7gJCj/gvBF9+Isd16oE0xuA5xwlGcFHbRfUFSON5EP2Lv8Eg==",
-          "requires": {
-            "@subsquid/util-internal-hex": "^1.2.1",
-            "@subsquid/util-internal-json": "^1.2.1"
-          }
-        },
-        "@subsquid/substrate-data": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/@subsquid/substrate-data/-/substrate-data-3.0.1.tgz",
-          "integrity": "sha512-zmZGtwYwNi50siU5k0r8YRXlJPNsls1E6y1N+Yv7driNdsolKhXdcHKLoRIaiXRlV/QGkuSh/vNaLxebxiL1TQ==",
-          "requires": {
-            "@subsquid/scale-codec": "^4.0.0",
-            "@subsquid/substrate-data-raw": "^0.1.0",
-            "@subsquid/util-internal": "^2.5.2",
-            "@subsquid/util-internal-hex": "^1.2.1",
-            "@subsquid/util-internal-ingest-tools": "^0.0.2",
-            "@subsquid/util-internal-range": "^0.0.1",
-            "@subsquid/util-xxhash": "^1.2.1",
-            "@substrate/calc": "^0.2.8",
-            "blake2b": "^2.1.4"
-          }
-        },
-        "@subsquid/substrate-data-raw": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/@subsquid/substrate-data-raw/-/substrate-data-raw-0.1.0.tgz",
-          "integrity": "sha512-0540hjZzUgeVjqy7UqKcTPKBsun2eisv9JR0ks3WDHPLabyWy4TolbE1WWqCo4B8wBmLEm5+vTL/BtM/AkHrYg==",
-          "requires": {
-            "@subsquid/util-internal": "^2.5.2",
-            "@subsquid/util-internal-ingest-tools": "^0.0.2",
-            "@subsquid/util-internal-range": "^0.0.1"
-          }
-        },
         "@subsquid/util-internal": {
-          "version": "2.5.2",
-          "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-2.5.2.tgz",
-          "integrity": "sha512-N7lfZdWEkM35jG5wdGYx25TJKGGLMOx9VInSeRhW9T/3BEmHAuSWI2mIIYnZ8w5L041V8HGo61ijWF6qsXvZjg=="
-        },
-        "@subsquid/util-internal-archive-client": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/@subsquid/util-internal-archive-client/-/util-internal-archive-client-0.0.1.tgz",
-          "integrity": "sha512-Sr+m1vxAArPIdsjyKVOpjU57JlVujBpI8NEeHqeA6twSb40wasOLAeq775WyYFynucltNRSgIiwXBIo0t02D6g==",
-          "requires": {
-            "@subsquid/http-client": "^1.3.1",
-            "@subsquid/util-internal": "^2.5.2",
-            "@subsquid/util-internal-range": "^0.0.1"
-          }
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-3.0.0.tgz",
+          "integrity": "sha512-aGPTiLF21N9f67DgHS4PBR8d6mdvXHTOIhr2mFQPX7GQCgZhNlCZDM/1Sqn+teJawCy3w6Y9f6KOtVbN4T5SFQ=="
         }
       }
     },
     "@subsquid/substrate-runtime": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@subsquid/substrate-runtime/-/substrate-runtime-1.0.1.tgz",
-      "integrity": "sha512-L7ln2EaIfl99uAbkz3Nw6oIXdpj2yfBk5qUyOJ/nOm5WHGBE3NKw0nIfgnC6EbbsNJKZZfJT0Tm+eRZZlUakug==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@subsquid/substrate-runtime/-/substrate-runtime-1.0.3.tgz",
+      "integrity": "sha512-3uNZqyHKzoMkSHQTZIJl1G7NiKyFl4cmDzVY3dU0o4VZhGNUAmR+HecT3WBkMMYye6uhDAeXsbVECa3ZnMM3gQ==",
       "peer": true,
       "requires": {
-        "@subsquid/scale-codec": "^4.0.0",
-        "@subsquid/scale-type-system": "^1.0.0",
-        "@subsquid/util-internal": "^2.5.2",
-        "@subsquid/util-internal-hex": "^1.2.1",
-        "@subsquid/util-naming": "^1.2.1",
-        "@subsquid/util-xxhash": "^1.2.1",
+        "@subsquid/scale-codec": "^4.0.1",
+        "@subsquid/scale-type-system": "^1.0.2",
+        "@subsquid/util-internal": "^3.0.0",
+        "@subsquid/util-internal-hex": "^1.2.2",
+        "@subsquid/util-naming": "^1.2.2",
+        "@subsquid/util-xxhash": "^1.2.2",
         "blake2b": "^2.1.4"
       },
       "dependencies": {
-        "@subsquid/scale-codec": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/@subsquid/scale-codec/-/scale-codec-4.0.0.tgz",
-          "integrity": "sha512-aVqcy1KeQiYhL3lRLZJcRVuBOmh88zQKqEdxU/7gJCj/gvBF9+Isd16oE0xuA5xwlGcFHbRfUFSON5EP2Lv8Eg==",
-          "peer": true,
-          "requires": {
-            "@subsquid/util-internal-hex": "^1.2.1",
-            "@subsquid/util-internal-json": "^1.2.1"
-          }
-        },
-        "@subsquid/scale-type-system": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@subsquid/scale-type-system/-/scale-type-system-1.0.1.tgz",
-          "integrity": "sha512-CjY5nBzGrbRcOH//lOwNHbBjHtHD0t27SirdIAFre/Mp4fLIiv6gEkIgNYu+lwAjMvuFkLkcw7JGmwXvLNepNw==",
-          "peer": true,
-          "requires": {
-            "@subsquid/util-internal": "^2.5.2"
-          }
-        },
         "@subsquid/util-internal": {
-          "version": "2.5.2",
-          "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-2.5.2.tgz",
-          "integrity": "sha512-N7lfZdWEkM35jG5wdGYx25TJKGGLMOx9VInSeRhW9T/3BEmHAuSWI2mIIYnZ8w5L041V8HGo61ijWF6qsXvZjg==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-3.0.0.tgz",
+          "integrity": "sha512-aGPTiLF21N9f67DgHS4PBR8d6mdvXHTOIhr2mFQPX7GQCgZhNlCZDM/1Sqn+teJawCy3w6Y9f6KOtVbN4T5SFQ==",
           "peer": true
         }
       }
@@ -21824,6 +21857,22 @@
       "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-1.1.0.tgz",
       "integrity": "sha512-O6m666RDcWEw4vb3bmeNZKlAa1rGOHQvS0nhZFTBXnxZpqK/pU5N0jrQ7X/3is0pY2RKxFoxTurZjhv4QdxtqA=="
     },
+    "@subsquid/util-internal-archive-client": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-archive-client/-/util-internal-archive-client-0.1.0.tgz",
+      "integrity": "sha512-bXFNZvXduKzG3NjPLmFPU5B+r+UHXT45Yr5YOpgD9sZvrHbNc/n877jSEt1qnzUJKnTl1hxtXlXvpwIBEjKT3Q==",
+      "requires": {
+        "@subsquid/util-internal": "^3.0.0",
+        "@subsquid/util-internal-range": "^0.1.0"
+      },
+      "dependencies": {
+        "@subsquid/util-internal": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-3.0.0.tgz",
+          "integrity": "sha512-aGPTiLF21N9f67DgHS4PBR8d6mdvXHTOIhr2mFQPX7GQCgZhNlCZDM/1Sqn+teJawCy3w6Y9f6KOtVbN4T5SFQ=="
+        }
+      }
+    },
     "@subsquid/util-internal-binary-heap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@subsquid/util-internal-binary-heap/-/util-internal-binary-heap-1.0.0.tgz",
@@ -21851,89 +21900,89 @@
       }
     },
     "@subsquid/util-internal-counters": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-counters/-/util-internal-counters-1.3.1.tgz",
-      "integrity": "sha512-bc22t8lEvoCBn31F+B763E81+ZDaL7ufpwr0VLXZzcA5wZ6NEqqRfs4bJtPeBNGEjyeLLrItXWxfjSkR7sGKAg=="
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-counters/-/util-internal-counters-1.3.2.tgz",
+      "integrity": "sha512-GxpOIL36JXSo0KdOT7k6CsI4DY804rn/X7pTdfKhych0ReHaDghnwNyvgb7Njv9euEHWUt4MxXbfQ9YrbpPDng=="
     },
     "@subsquid/util-internal-hex": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-hex/-/util-internal-hex-1.2.1.tgz",
-      "integrity": "sha512-R7TYDsftjguapzWia97WGvcF4s65VKArzSga5i1i4aZSq9Z330kPYpgAUkqDGsJqD/Ki3PTE4cXhuKLRyMHPvg=="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-hex/-/util-internal-hex-1.2.2.tgz",
+      "integrity": "sha512-E43HVqf23jP5hvtWF9GsiN8luANjnJ1daR2SVTwaIUAYU/uNjv1Bi6tHz2uexlflBhyxAgBDmHgunXZ45wQTIw=="
     },
     "@subsquid/util-internal-http-server": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-http-server/-/util-internal-http-server-1.2.1.tgz",
-      "integrity": "sha512-aQIodM3xWDu8wxllOONU5Fy6hmYYAZzS2PglC2FfdUi6HUxaZ8aCUkjFisG56tglhsoAh/TQSQX1YhCX00MCcg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-http-server/-/util-internal-http-server-1.2.2.tgz",
+      "integrity": "sha512-B2SOSz8frUkXarbsELljew25iXFFyATEtS8NV31xKUXmhYfPklqrcF4YNJ/aLlfCtVOiR042YKVZDx2T8RbN6w==",
       "requires": {
         "stoppable": "^1.1.0"
       }
     },
     "@subsquid/util-internal-ingest-tools": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-ingest-tools/-/util-internal-ingest-tools-0.0.2.tgz",
-      "integrity": "sha512-Nx5LDWq9B1sVAXg6qDI0zVmzfwP1Mk5Rrn79OJc4eKLvZTrTIk2vyM5SB4n1kwQk6KRuQYI9dfiNWdcm+9rGfA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-ingest-tools/-/util-internal-ingest-tools-1.1.0.tgz",
+      "integrity": "sha512-Zk5IPrclv+OrAV6EFQWGQS86YfN51/tLKKW137VzFPCWNEBSPCXu5lYe/hCwwW34k+gtf5TYLb3s69d2P1e/lg==",
       "requires": {
-        "@subsquid/logger": "^1.3.1",
-        "@subsquid/util-internal": "^2.5.2",
-        "@subsquid/util-internal-range": "^0.0.1"
+        "@subsquid/logger": "^1.3.2",
+        "@subsquid/util-internal": "^3.0.0",
+        "@subsquid/util-internal-range": "^0.1.0"
       },
       "dependencies": {
         "@subsquid/util-internal": {
-          "version": "2.5.2",
-          "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-2.5.2.tgz",
-          "integrity": "sha512-N7lfZdWEkM35jG5wdGYx25TJKGGLMOx9VInSeRhW9T/3BEmHAuSWI2mIIYnZ8w5L041V8HGo61ijWF6qsXvZjg=="
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-3.0.0.tgz",
+          "integrity": "sha512-aGPTiLF21N9f67DgHS4PBR8d6mdvXHTOIhr2mFQPX7GQCgZhNlCZDM/1Sqn+teJawCy3w6Y9f6KOtVbN4T5SFQ=="
         }
       }
     },
     "@subsquid/util-internal-json": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-json/-/util-internal-json-1.2.1.tgz",
-      "integrity": "sha512-Jtbhur/QaRk727fiZ/w8so0M0o4BIkfvnT6zBnC3s1mQ9fKve0Q6aj22gbimpX7Whj6tAGF0Bz8LFhbAethbkA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-json/-/util-internal-json-1.2.2.tgz",
+      "integrity": "sha512-+axQnlkIzscdy0T/vR1Dez/2NVCryWgB3OocMGJcx2GjhHVkmuJSLFqOdk9o90OocfQFC57NTZx22oa2yd+4Yw==",
       "requires": {
-        "@subsquid/util-internal-hex": "^1.2.1"
+        "@subsquid/util-internal-hex": "^1.2.2"
       }
     },
     "@subsquid/util-internal-processor-tools": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-processor-tools/-/util-internal-processor-tools-3.1.0.tgz",
-      "integrity": "sha512-uEa8Bw/xvSfiagbK8IFt1OEgR7hacfblPZXH5EV4cAIKoIVOonhnkJEPRWqI3ZaDHl+8Z9p909tlsEd46sXenw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-processor-tools/-/util-internal-processor-tools-4.0.1.tgz",
+      "integrity": "sha512-2+IOze7VkgUuJqRThzq6QDO+xNd6CAbPUgtjgOi6EB3/ImrJXEjENBOFzTVSTP0Ri+kT/CyoyBPniyGBGzogiA==",
       "requires": {
-        "@subsquid/logger": "^1.3.1",
-        "@subsquid/util-internal": "^2.5.2",
-        "@subsquid/util-internal-counters": "^1.3.1",
-        "@subsquid/util-internal-prometheus-server": "^1.2.1",
-        "@subsquid/util-internal-range": "^0.0.1",
+        "@subsquid/logger": "^1.3.2",
+        "@subsquid/util-internal": "^3.0.0",
+        "@subsquid/util-internal-counters": "^1.3.2",
+        "@subsquid/util-internal-prometheus-server": "^1.2.2",
+        "@subsquid/util-internal-range": "^0.1.0",
         "prom-client": "^14.2.0"
       },
       "dependencies": {
         "@subsquid/util-internal": {
-          "version": "2.5.2",
-          "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-2.5.2.tgz",
-          "integrity": "sha512-N7lfZdWEkM35jG5wdGYx25TJKGGLMOx9VInSeRhW9T/3BEmHAuSWI2mIIYnZ8w5L041V8HGo61ijWF6qsXvZjg=="
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-3.0.0.tgz",
+          "integrity": "sha512-aGPTiLF21N9f67DgHS4PBR8d6mdvXHTOIhr2mFQPX7GQCgZhNlCZDM/1Sqn+teJawCy3w6Y9f6KOtVbN4T5SFQ=="
         }
       }
     },
     "@subsquid/util-internal-prometheus-server": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-prometheus-server/-/util-internal-prometheus-server-1.2.1.tgz",
-      "integrity": "sha512-GhbsEmv0xAkaBaxwZGRavMIO0h68V6LctZIvxsrrPr695bI1mrXKSYDvVvUwLXQ3aDPy9PIQiKdbSjNa60JW6Q==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-prometheus-server/-/util-internal-prometheus-server-1.2.2.tgz",
+      "integrity": "sha512-KOjokVhs+qJOZSkM+NPZ/XE5bGvEGGJkVbMaJJfaZ+UfZQPQDfVJrI2rPV5D9FwzctxKG9b7lPArryBIUsgrZw==",
       "requires": {
-        "@subsquid/util-internal-http-server": "^1.2.1"
+        "@subsquid/util-internal-http-server": "^1.2.2"
       }
     },
     "@subsquid/util-internal-range": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-range/-/util-internal-range-0.0.1.tgz",
-      "integrity": "sha512-9hqlPdTJeR9j9+1L3ymOPC0/qJ2IemGkrHmkTq+gwkjtGKmiXuXw4WLgt0Ps5aeupWKfP7UFy1hDE9DZQFseog==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-range/-/util-internal-range-0.1.0.tgz",
+      "integrity": "sha512-+pJeJyH0oetqu2eRwOkP7NCSaCGzLpCCNpS9Fwi968RL+LfWSKn+wGUX6Ulf0afSslvrQ/34ZtyWdjyya1AGxA==",
       "requires": {
-        "@subsquid/util-internal": "^2.5.2",
+        "@subsquid/util-internal": "^3.0.0",
         "@subsquid/util-internal-binary-heap": "^1.0.0"
       },
       "dependencies": {
         "@subsquid/util-internal": {
-          "version": "2.5.2",
-          "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-2.5.2.tgz",
-          "integrity": "sha512-N7lfZdWEkM35jG5wdGYx25TJKGGLMOx9VInSeRhW9T/3BEmHAuSWI2mIIYnZ8w5L041V8HGo61ijWF6qsXvZjg=="
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-3.0.0.tgz",
+          "integrity": "sha512-aGPTiLF21N9f67DgHS4PBR8d6mdvXHTOIhr2mFQPX7GQCgZhNlCZDM/1Sqn+teJawCy3w6Y9f6KOtVbN4T5SFQ=="
         }
       }
     },
@@ -21944,18 +21993,23 @@
       "dev": true
     },
     "@subsquid/util-naming": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-naming/-/util-naming-1.2.1.tgz",
-      "integrity": "sha512-l5rvAXG7TxMPeB5kFTTZWisgN0DNe1mVBHT2V2/nxUx4sOfYfneWIN/+02YqJI/GHX9FoOTB6ru7WLfQEMhvhg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-naming/-/util-naming-1.2.2.tgz",
+      "integrity": "sha512-NveXOiAbWiWkWd3Iv2jEwSAKvQHOG/HfIsPmmNab8TPX/XgJ6J5Ngx6lHEiqs746m4sOhZ2yipxKAEDgrERaxA==",
       "requires": {
         "camelcase": "^6.3.0",
         "inflected": "^2.1.0"
       }
     },
+    "@subsquid/util-timeout": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-timeout/-/util-timeout-2.3.2.tgz",
+      "integrity": "sha512-DVUnuiWAX7/4ZvbzuHENUShEEV4G0M38mQ/+R8DpHxwpCSrtEaSRaUMwdyUSn/WVqR7wo9+jkLCxFjE5feCURQ=="
+    },
     "@subsquid/util-xxhash": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-xxhash/-/util-xxhash-1.2.1.tgz",
-      "integrity": "sha512-wobgbKK0fd+3ufUVjxcx4zaYII9JY7hbIStyO9M9Q5xrdihiWM5APX27sRuoO8X8oSj34v44JpIMxC8Rbpy3xQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-xxhash/-/util-xxhash-1.2.2.tgz",
+      "integrity": "sha512-S49O4bxs80y3/oBl1xKBE/zzvDPLr88yE+03zfOXaNj/wesTGzicqBxhzDULmyo6kpdRmc0ZPOZCQ3U6gNQpxQ==",
       "requires": {
         "xxhash-wasm": "^1.0.2",
         "xxhashjs": "^0.2.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "storage-squid",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "engines": {
     "node": ">=16"
   },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@subsquid/archive-registry": "^3.3.0",
     "@subsquid/graphql-server": "^4.3.1",
     "@subsquid/ss58": "^2.0.1",
-    "@subsquid/substrate-processor": "^7.2.1",
+    "@subsquid/substrate-processor": "^8.1.1",
     "@subsquid/typeorm-migration": "^1.2.2",
     "@subsquid/typeorm-store": "^1.2.4",
     "async-lock": "^1.3.1",


### PR DESCRIPTION
This PR bumps the  `subsquid/substrate-processor` package version from `^7.2.1` to `^8.1.1`. `8.1.1` has a dependency on `"@subsquid/util-internal-processor-tools": "^4.0.0"`, so running `npm install` will download & lock `4.0.1` version of `util-internal-processor-tools` which includes the fix for switching to RPC when archive head is reached