### PR TITLE
add env variable for RPC rate limit

### DIFF
--- a/.env
+++ b/.env
@@ -16,6 +16,9 @@ ARCHIVE_GATEWAY_URL=${CUSTOM_ARCHIVE_GATEWAY_URL:-https://v2.archive.subsquid.io
 # Use private endpoints in production!
 RPC_ENDPOINT=wss://rpc.joystream.org:9944
 
+# Rate limit for RPC sync
+RPC_RATE_LIMIT=10
+
 # Uncommenting this line enables the debug mode
 # More info at https://docs.subsquid.io/basics/logging/
 #SQD_DEBUG=*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.4.3
+
+- Allow configuring RPC rate limit via `RPC_RATE_LIMIT` environment variable.
+
 # 1.4.2
 
 - **FIX**: Bump Subsquid processor (`@subsquid/substrate-processor`) version to include fix for switching to RPC when processing unfinalized blocks.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "storage-squid",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "engines": {
     "node": ">=16"
   },

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -117,6 +117,7 @@ const eventNames = Object.keys(eventHandlers)
 const archiveUrl = process.env.ARCHIVE_GATEWAY_URL
 
 const rpcURL = process.env.RPC_ENDPOINT || 'http://localhost:9944/'
+const rpcRateLimit = parseInt(process.env.RPC_RATE_LIMIT || '10')
 
 const maxCachedEntities = parseInt(process.env.MAX_CACHED_ENTITIES || '1000')
 
@@ -124,7 +125,7 @@ PROCESSOR.setDataSource({
   ...(archiveUrl ? { archive: archiveUrl } : {}),
   chain: {
     url: rpcURL,
-    rateLimit: 10,
+    rateLimit: rpcRateLimit,
   },
 }).addEvent({
   name: eventNames,


### PR DESCRIPTION
Allow configuring RPC rate limit via `RPC_RATE_LIMIT` environment variable.